### PR TITLE
Fixes broken link

### DIFF
--- a/standards/PHP.md
+++ b/standards/PHP.md
@@ -59,8 +59,8 @@ interpreted as described in [RFC 2119].
   exist at the very beginning/ending of the body of another function or control
   structure.
 
-- Control structure keywords MUST NOT use their [alternative syntaxes] (`elseif`,
-  `endif`, etc.).
+- Control structure keywords MUST NOT use their [alternative syntaxes](alternative syntaxes) 
+  (`elseif`, `endif`, etc.).
 
 - Control structure keywords MUST have one space after them; method and
   function calls MUST NOT.


### PR DESCRIPTION
Having a bracket directly after a square bracket makes the markdown parser think the content after that bracket is a link. As the page https://github.com/pixelandtonic/CodingStandards/blob/master/standards/%60elseif%60,%0A%60endif%60,%20etc. does not exist I assume this was an oversight.

Adding the text in the square brackets again in brackets looks a bit lame, alternatives would be to either not use brackets in the sentence or use a short (for instance numeric) id for the link. Adding any other character than whitespace would also work.
